### PR TITLE
TaskPlanner and baro objects are created outside the library

### DIFF
--- a/FC_MS5611_Lib.cpp
+++ b/FC_MS5611_Lib.cpp
@@ -166,11 +166,11 @@ void FC_MS5611_Lib::calculatePressureAndTemperatureFromRawData()
 	
 	
 	// Smooth the value
-	if (abs(lastSmoothPressure - pressure) > 1)
+	if (abs(smoothPressure - pressure) > 1)
 		smoothPressure = smoothPressure*0.72f + pressure*0.28f;
 	else
 		smoothPressure = smoothPressure*0.96f + pressure*0.04f;
-	lastSmoothPressure = smoothPressure;
+
 
 	// Call function added by the user (if not null)
 	if (newBaroReadingFunctionPointer != nullptr)

--- a/FC_MS5611_Lib.cpp
+++ b/FC_MS5611_Lib.cpp
@@ -61,13 +61,12 @@ bool FC_MS5611_Lib::initialize(bool needToBeginWire_flag)
 	SENS_C1 = C[1] * pow(2, 15);
 	
 	
-	
-	
+
 	// Schedule first baro reading action
-	taskPlanner->scheduleTask(requestPressureStartTask, 8);
+	requestPressureStartTask();
 	
 	
-	
+
 	// The MS5611 needs a few readings to stabilize
 	// Read pressure for 400ms
 	uint32_t readingEndTime = millis() + 400;
@@ -186,7 +185,7 @@ void requestPressureStartTask()
 	baroPtr->requestPressureFromDevice();
 	
 	// Schedule first pressure action
-	baroPtr->taskPlanner->scheduleTask(pressureAction, 9);
+	baroPtr->taskPlanner->scheduleTask(pressureAction, FC_MS5611_Lib::REQUEST_WAIT_TIME);
 }
 
 void pressureAction()
@@ -198,12 +197,12 @@ void pressureAction()
 	if (baroPtr->actionCounter == 20)
 	{
 		baroPtr->requestTemperatureFromDevice();
-		baroPtr->taskPlanner->scheduleTask(temperatureAction, 9);
+		baroPtr->taskPlanner->scheduleTask(temperatureAction, FC_MS5611_Lib::REQUEST_WAIT_TIME);
 	}
 	else
 	{
 		baroPtr->requestPressureFromDevice();
-		baroPtr->taskPlanner->scheduleTask(pressureAction, 9);
+		baroPtr->taskPlanner->scheduleTask(pressureAction, FC_MS5611_Lib::REQUEST_WAIT_TIME);
 	}
 }
 
@@ -213,7 +212,7 @@ void temperatureAction()
 	baroPtr->calculatePressureAndTemperatureFromRawData();
 	baroPtr->requestPressureFromDevice();
 	baroPtr->actionCounter = 1;
-	baroPtr->taskPlanner->scheduleTask(pressureAction, 9);
+	baroPtr->taskPlanner->scheduleTask(pressureAction, FC_MS5611_Lib::REQUEST_WAIT_TIME);
 }
 
 

--- a/FC_MS5611_Lib.cpp
+++ b/FC_MS5611_Lib.cpp
@@ -86,13 +86,13 @@ void FC_MS5611_Lib::setFastClock()
 }
 
 
-float FC_MS5611_Lib::getPressure()
+pressureType FC_MS5611_Lib::getPressure()
 {
 	return pressure;
 }
 
 
-float FC_MS5611_Lib::getSmoothPressure()
+pressureType FC_MS5611_Lib::getSmoothPressure()
 {
 	return smoothPressure;
 }

--- a/FC_MS5611_Lib.h
+++ b/FC_MS5611_Lib.h
@@ -59,7 +59,6 @@ class FC_MS5611_Lib
 	uint32_t rawTemperature;
 	int32_t intPressure; // temp pressure value (before average pressure is in integer)
 	float smoothPressure; // smoother pressure value (in mbar*100)
-	float lastSmoothPressure; // used to calculate the smooth pressure value
 	float pressure; // pressure in mbar*100
 	
 	// this counter is used to get temperature every 20 readings

--- a/FC_MS5611_Lib.h
+++ b/FC_MS5611_Lib.h
@@ -11,19 +11,21 @@
 #include <FC_TaskPlanner.h>
 #include <FC_AverageFilter.h>
 
+#define pressureType float // This can be float or double (float should be enough but I'm not 100% sure)
+
 
 class FC_MS5611_Lib
 {
- public:
+public:
 	FC_MS5611_Lib(FC_TaskPlanner* taskPlannerPtr);
 	bool initialize(bool needToBeginWire_flag = true);
 	void setFastClock();
-	float getPressure(); // new pressure value is updated about 111 times per second
-	float getSmoothPressure(); // same as getPressure but smoother
+	pressureType getPressure(); // new pressure value is updated about 111 times per second
+	pressureType getSmoothPressure(); // same as getPressure but smoother
 	void registerNewBaroReadingFunction(void (*functionPointer)()); // When baro get new reading this function will be called
 
 	
- private:
+private:
 	void requestPressureFromDevice();
 	void getRawPressureFromDevice(); // need to request first!
 	void requestTemperatureFromDevice();
@@ -39,9 +41,9 @@ class FC_MS5611_Lib
 	
 	
 	
- private:
+private:
 	FC_TaskPlanner* taskPlanner; // task planner should have capability of storing at least 2 tasks at once
-	FC_AverageFilter<int32_t, int32_t, double> pressureFilter; // initialized in the constructor
+	FC_AverageFilter<int32_t, int32_t, pressureType> pressureFilter; // initialized in the constructor
 	
 	static const uint8_t MS5611_Address = 0x77;
 	static const uint8_t REQUEST_WAIT_TIME = 9; // time in ms between value request and ready to read from device
@@ -58,8 +60,8 @@ class FC_MS5611_Lib
 	uint32_t rawPressure;
 	uint32_t rawTemperature;
 	int32_t intPressure; // temp pressure value (before average pressure is in integer)
-	float smoothPressure; // smoother pressure value (in mbar*100)
-	float pressure; // pressure in mbar*100
+	pressureType smoothPressure; // smoother pressure value (in mbar*100)
+	pressureType pressure; // pressure in mbar*100
 	
 	// this counter is used to get temperature every 20 readings
 	uint8_t actionCounter = 0;

--- a/FC_MS5611_Lib.h
+++ b/FC_MS5611_Lib.h
@@ -5,11 +5,7 @@
 #ifndef _FC_MS5611_LIB_h
 #define _FC_MS5611_LIB_h
 
-#if defined(ARDUINO) && ARDUINO >= 100
-	#include "arduino.h"
-#else
-	#include "WProgram.h"
-#endif
+#include "arduino.h"
 
 #include <Wire.h>
 #include <FC_TaskPlanner.h>
@@ -19,18 +15,13 @@
 class FC_MS5611_Lib
 {
  public:
-	FC_MS5611_Lib();
+	FC_MS5611_Lib(FC_TaskPlanner* taskPlannerPtr);
 	bool initialize(bool needToBeginWire_flag = true);
 	void setFastClock();
 	float getPressure(); // new pressure value is updated about 111 times per second
 	float getSmoothPressure(); // same as getPressure but smoother
-	void runBarometer(); // called in the main loop() AS FAST AS POSSIBLE
 	void registerNewBaroReadingFunction(void (*functionPointer)()); // When baro get new reading this function will be called
-	
-	// friend functions used in the TaskPlanner
-	friend void requestPressureStartTask();
-	friend void pressureAction();
-	friend void temperatureAction();
+
 	
  private:
 	void requestPressureFromDevice();
@@ -38,12 +29,18 @@ class FC_MS5611_Lib
 	void requestTemperatureFromDevice();
 	void getRawTemperatreFromDevice(); // need to request first!
 	void calculatePressureAndTemperatureFromRawData(); // after requesting raw data
+
+
+	// friend functions used in the TaskPlanner
+	friend void requestPressureStartTask();
+	friend void pressureAction();
+	friend void temperatureAction();
 	
 	
 	
 	
  private:
-	FC_TaskPlanner taskPlanner = FC_TaskPlanner(3); // max 3 tasks will be planned at single moment
+	FC_TaskPlanner* taskPlanner; // task planner should have capability of storing at least 2 tasks at once
 	FC_AverageFilter<int32_t, int32_t, double> pressureFilter; // initialized in the constructor
 	
 	static const uint8_t MS5611_Address = 0x77;
@@ -70,9 +67,6 @@ class FC_MS5611_Lib
 
 	void (*newBaroReadingFunctionPointer)() = nullptr;
 };
-
-
-extern FC_MS5611_Lib baro;
 
 
 #endif

--- a/FC_MS5611_Lib.h
+++ b/FC_MS5611_Lib.h
@@ -44,7 +44,7 @@ class FC_MS5611_Lib
 	FC_AverageFilter<int32_t, int32_t, double> pressureFilter; // initialized in the constructor
 	
 	static const uint8_t MS5611_Address = 0x77;
-	static const uint8_t AFTER_REQUEST_WAIT_TIME = 8;
+	static const uint8_t REQUEST_WAIT_TIME = 9; // time in ms between value request and ready to read from device
 	
 	
 	// Device calibration values

--- a/FC_MS5611_example/FC_MS5611_example.ino
+++ b/FC_MS5611_example/FC_MS5611_example.ino
@@ -4,12 +4,23 @@
     Author:     Jan Wielgus
 */
 
+#include <Wire.h>
+#include <FC_TaskPlanner.h>
+#include <FC_AverageFilter.h> // used inside baro library
 #include "FC_MS5611_Lib.h"
 
 
-//FC_MS5611_Lib baro; // Baro object is created inside the library
+// task planner used for baro should have capability of at least 2 tasks at once
+// Can be higher when also used fo other purposes
+FC_TaskPlanner baroTaskPlanner(3);
 
-void showPressure(); // this function show pressure in 80Hz
+// Create barometer instance and pass the task planner
+// There CANNOT be more than one instance of the barometer class
+// Singleton design pattern is not used, because this make drone code inconsistent
+FC_MS5611_Lib baro(&baroTaskPlanner);
+
+// this function show pressure in 80Hz (I'm not sure, maybe 110Hz)
+void showPressure();
 
 
 void setup()
@@ -29,7 +40,7 @@ void setup()
 		delay(500);
 	}
 	
-	// This function will be executed if new baro reading will be available
+	// This function will be executed if new baro reading is available
 	baro.registerNewBaroReadingFunction(showPressure);
 	
 	Serial.println("Setup completed");
@@ -38,16 +49,19 @@ void setup()
 
 void loop()
 {
-	baro.runBarometer();
+	// Remember to call the task planner as fast as possible
+	// This is used to take measurements just in time
+	// This should be the only thing inside the loop() (except for tasker run() method)
+	baroTaskPlanner.runPlanner();
 }
 
 
 
 void showPressure()
 {
-	Serial.print("Pressure: ");
+	Serial.print("Pressure:");
 	Serial.print(baro.getPressure());
-	Serial.print(" SmoothPres: ");
+	Serial.print(" SmoothPres:");
 	Serial.print(baro.getSmoothPressure());
 	Serial.println();
 }


### PR DESCRIPTION
I have figured out how to get rid of creating barometer instance inside the library and extern it for other programs. Just instead of making an instance create a pointer which will be assigned the proper value in the baro constructor.

TaskPlanner which is now created outside the baro library. It makes possible to add other planned tasks by other programs.